### PR TITLE
Readme: Add note about React 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,18 @@ if (process.env.NODE_ENV === 'development') {
 
 ## Installation
 
+### For React 18+
+
 ```sh
 yarn add simple-zustand-devtools --dev
+```
+
+### For React 17
+
+Use [a release prior to 1.0.2](https://www.npmjs.com/package/simple-zustand-devtools?activeTab=versions) for React 17.
+
+```sh
+npm install simple-zustand-devtools@1.0.2 --save-dev --legacy-peer-deps
 ```
 
 ## Docs


### PR DESCRIPTION
It looks like the breaking changes for React 17 from https://github.com/beerose/simple-zustand-devtools/pull/24 where [merged as 1.0.2 first](https://github.com/beerose/simple-zustand-devtools/blame/867096a404a3e6ed3245875ff0a4df5a9d94c240/package.json) (and then released again as 1.1.0?). So anything prior to 1.0.2 should be fine for React 17, right?